### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/micheljarjous/juice-shop-ADA-1466/security/code-scanning/54](https://github.com/micheljarjous/juice-shop-ADA-1466/security/code-scanning/54)

To remediate this vulnerability, avoid ever passing untrusted user input into a `$where` clause or similar constructs that evaluate strings as code. The best fix is to use a safe, data-driven query rather than a code-based query. For MongoDB collections, searching for an order by its ID should use a field-based query:
```js
db.ordersCollection.find({ orderId: id });
```
This avoids both code injection and performance issues.

For the relevant code block in `routes/trackOrder.ts`, replace:
```js
db.ordersCollection.find({ $where: `this.orderId === '${id}'` })
```
with:
```js
db.ordersCollection.find({ orderId: id })
```
No additional library imports are needed. Ensure that the rest of the logic (challenge-solving, result handling) remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
